### PR TITLE
bump/jandex

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group                = org.kordamp.gradle
 sourceCompatibility  = 1.8
 targetCompatibility  = 1.8
 
-jandexVersion        = 2.2.3.Final
+jandexVersion        = 2.3.0.Final
 kordampPluginVersion = 0.45.0
 kordampBuildVersion  = 2.4.0
 


### PR DESCRIPTION
This update the jandex version used by the plugin to 2.3.0.Final 