### PR TITLE
Bump Jandex version to 2.3.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 :project-name:    jandex-gradle-plugin
 :project-group:   org.kordamp.gradle
 :project-version: 0.11.0
-:jandex-version:  2.3.0.Final
+:jandex-version:  2.3.1.Final
 :plugin-id:       {project-group}.jandex
 
 image:https://github.com/{project-owner}/{project-name}/workflows/Build/badge.svg["Build Status", link="https://github.com/{project-owner}/{project-name}/actions"]

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group                = org.kordamp.gradle
 sourceCompatibility  = 1.8
 targetCompatibility  = 1.8
 
-jandexVersion        = 2.3.0.Final
+jandexVersion        = 2.3.1.Final
 kordampPluginVersion = 0.46.0
 kordampBuildVersion  = 2.5.0
 

--- a/src/main/groovy/org/kordamp/gradle/plugin/jandex/JandexPlugin.groovy
+++ b/src/main/groovy/org/kordamp/gradle/plugin/jandex/JandexPlugin.groovy
@@ -45,7 +45,7 @@ class JandexPlugin implements Plugin<Project> {
         jandexConfiguration.defaultDependencies(new Action<DependencySet>() {
             @Override
             void execute(DependencySet dependencies) {
-                dependencies.add(project.dependencies.create('org.jboss:jandex:2.3.0.Final'))
+                dependencies.add(project.dependencies.create('org.jboss:jandex:2.3.1.Final'))
             }
         })
 


### PR DESCRIPTION
This bump the default jandex version to the latest one. 