### PR TITLE
Address deprecation of JavaExecSpec.main property

### DIFF
--- a/src/main/groovy/org/kordamp/gradle/plugin/jandex/tasks/JandexTask.groovy
+++ b/src/main/groovy/org/kordamp/gradle/plugin/jandex/tasks/JandexTask.groovy
@@ -123,7 +123,11 @@ class JandexTask extends DefaultTask {
                 args << destination.asFile.get().absolutePath
                 args.addAll(resolveSources())
 
-                jes.main = JandexMain.class.name
+                if (jes.hasProperty("mainClass")) {
+                    jes.mainClass = JandexMain.class.name
+                } else {
+                    jes.main = JandexMain.class.name
+                }
                 jes.classpath(resolveClasspath())
                 jes.args(args)
             }


### PR DESCRIPTION
Gradle has deprecated the `JavaExecSpec.getMain()` and `JavaExecSpec.setMain()`
methods in favour of the new `mainClass` property. 
The old methods are scheduled to be removed in Gradle 8.0, but Gradle already
warns about their deprecation when used.

This change addresses this issue by using the `mainClass` property instead.

See https://docs.gradle.org/7.4.2/userguide/upgrading_version_7.html#java_exec_properties for more information about the deprecation.