### PR TITLE
Handle non-existent sources

### DIFF
--- a/src/main/groovy/org/kordamp/gradle/plugin/jandex/tasks/JandexWorkAction.groovy
+++ b/src/main/groovy/org/kordamp/gradle/plugin/jandex/tasks/JandexWorkAction.groovy
@@ -46,9 +46,17 @@ abstract class JandexWorkAction implements WorkAction<JandexWorkParameters> {
 
         ClassFileVisitor classFileVisitor = new ClassFileVisitor(indexer)
         for (String src : parameters.sources.get()) {
-            logger.info("Indexing files at " + Paths.get(src).toAbsolutePath())
+            Path path = Paths.get(src)
+            if (!Files.exists(path)) {
+                // Source provided by Gradle does not exist.
+                // This happens when using Kotlin, where the Java class
+                // directory might not actually exist.
+                continue
+            }
 
-            Files.walkFileTree(Paths.get(src), classFileVisitor)
+            logger.info("Indexing files at " + path.toAbsolutePath())
+
+            Files.walkFileTree(path, classFileVisitor)
         }
 
         File destination = parameters.destination.asFile.get()


### PR DESCRIPTION
Hi,

I recently updated to version of 0.13.1 to be able to upgrade to Gradle v7.5. It seems however that the new worker-based implementation fails when using Kotlin, complaining about non-existent Java class directories. For instance, this is the error is get when using the latest versions in one of my projects: 

```
 Task :opendc-web:opendc-web-proto:jandex
java.nio.file.NoSuchFileException: /Users/fabian/Documents/Workspace/Projects/AtLarge Research/opendc/opendc-web/opendc-web-proto/build/classes/java/main
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:148)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1851)
        at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:220)
        at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:277)
        at java.base/java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:323)
        at java.base/java.nio.file.Files.walkFileTree(Files.java:2805)
        at java.base/java.nio.file.Files.walkFileTree(Files.java:2883)
        at org.kordamp.gradle.plugin.jandex.tasks.JandexWorkAction.execute(JandexWorkAction.groovy:51)
```

This pull request updates JandexWorkAction to support sources passed to the task that do not actually exist. 

By the way, it seems that the `jandex` task does not fail when `JandexWorkAction` throws an exception. In my project, Gradle reported the build to have completed successfully, even though `JandexWorkAction` failed. However, I am not familiar enough with the Gradle Worker API to be able to fix this.