### PR TITLE
fix: Add main sourceSet output to the inputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 
     compileOnly "io.smallrye:jandex:$jandexVersion"
     api "org.kordamp.gradle:base-gradle-plugin:$kordampPluginVersion"
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testImplementation 'org.assertj:assertj-core:3.11.1'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }
 
 processResources {
@@ -68,4 +73,26 @@ processResources {
             jandexVersion: jandexVersion
         )
     }
+}
+
+// Add a source set for the functional test suite
+sourceSets {
+    functionalTest {
+    }
+}
+
+gradlePlugin.testSourceSets(sourceSets.functionalTest)
+configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
+configurations.functionalTestRuntimeOnly.extendsFrom(configurations.testRuntimeOnly)
+
+// Add a task to run the functional tests
+tasks.register('functionalTest', Test) {
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    classpath = sourceSets.functionalTest.runtimeClasspath
+    useJUnitPlatform()
+}
+
+tasks.named('check') {
+    // Run the functional tests as part of `check`
+    dependsOn(tasks.functionalTest)
 }

--- a/src/functionalTest/groovy/org/kordamp/gradle/plugin/jandex/JandexPluginPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/org/kordamp/gradle/plugin/jandex/JandexPluginPluginFunctionalTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2023 Andres Almiray.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kordamp.gradle.plugin.jandex
+
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+
+class JandexPluginPluginFunctionalTest  {
+
+    private File projectDir
+
+    private getBuildFile() {
+        new File(projectDir, "build.gradle")
+    }
+
+    private getSettingsFile() {
+        new File(projectDir, "settings.gradle")
+    }
+
+    private getSourceFileAClass() {
+        new File(projectDir, 'src/main/java/com/sample').mkdirs()
+        new File(projectDir, 'src/main/java/com/sample/AClass.java')
+    }
+
+    @Test
+    void testApply() {
+        projectDir = new File("build/functionalTestFixture/apply_${System.currentTimeMillis()}")
+        projectDir.mkdirs()
+
+        def indexFile = new File(projectDir, 'build/resources/main/META-INF/jandex.idx')
+        Assertions.assertThat(indexFile).doesNotExist();
+
+        settingsFile.text = ""
+        buildFile.text = """
+plugins {
+    id 'org.kordamp.gradle.jandex'
+}
+
+repositories {
+    mavenCentral()
+}
+"""
+
+        sourceFileAClass.text = """
+package com.sample;
+
+public class AClass {
+	public void sayHi() {
+		System.out.println("hi");
+	}
+}
+"""
+        def runner1 = createRunner()
+        def result1 = runner1.build()
+        Assertions.assertThat(result1.task(':jandex').outcome).isEqualTo(TaskOutcome.SUCCESS);
+        Assertions.assertThat(indexFile).exists();
+        def content1 = indexFile.getText("UTF-8")
+        Assertions.assertThat(content1).contains("sayHi");
+
+        //Re run without any changes, to be sure the task is up-to-date:
+        def runner2 = createRunner()
+        def result2 = runner2.build()
+        Assertions.assertThat(result2.task(':jandex').outcome).isEqualTo(TaskOutcome.UP_TO_DATE);
+
+        //Modify source file, and verify jandex was executed again:
+        sourceFileAClass.text = """
+package com.sample;
+
+public class AClass {
+	public void sayHello() {
+		System.out.println("hello");
+	}
+}
+"""
+        def runner3 = createRunner()
+        def result3 = runner3.build()
+        Assertions.assertThat(result3.task(':jandex').outcome).isEqualTo(TaskOutcome.SUCCESS);
+        Assertions.assertThat(indexFile).exists();
+        def content3 = indexFile.getText("UTF-8")
+        Assertions.assertThat(content3)
+            .isNotEqualTo(content1)
+            .contains("sayHello");
+
+        //Re run without any changes, to be sure the task is up-to-date:
+        def runner4 = createRunner()
+        def result4 = runner4.build()
+        Assertions.assertThat(result4.task(':jandex').outcome).isEqualTo(TaskOutcome.UP_TO_DATE);
+    }
+
+    def createRunner() {
+        def runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("jandex", "--stacktrace")
+        runner.withProjectDir(projectDir)
+        return runner
+    }
+}

--- a/src/main/groovy/org/kordamp/gradle/plugin/jandex/JandexPlugin.groovy
+++ b/src/main/groovy/org/kordamp/gradle/plugin/jandex/JandexPlugin.groovy
@@ -73,6 +73,9 @@ class JandexPlugin implements Plugin<Project> {
                     t.processResourcesTask = project.tasks.named('processResources', Copy)
                     t.layout.set(project.layout)
                     t.sourceSets.addAll(project.extensions.findByType(SourceSetContainer))
+                    if (t.resolvedProcessDefaultFileSet.get()) {
+                        t.inputs.files(t.sourceSets.findByName('main').output.classesDirs*.absolutePath.flatten())
+                    }
                 }
             })
 


### PR DESCRIPTION
Fixes #24

As discussed in the issue, the `resolveSources()` method is adding the main sourceSet output to the list of files sent to jandex.
https://github.com/kordamp/jandex-gradle-plugin/blob/8b9f8795c02034dbf73af9d18b77e60afa76cb21/src/main/groovy/org/kordamp/gradle/plugin/jandex/tasks/JandexTask.groovy#L155-L157

So for me this belongs to the task input in order to avoid the task to stay `UP-TO-DATE` when there is a change.

---

There was no guidance on functional tests in this repository.
So I used what is generated by `gradle init` as input but I did not used Spock.
If the setup is not the one that is expected, feel free to point me to other repositories where you have already functional tests.
Or if you prefer not having them, this can also be removed from this PR.

The test itself contains the reproducer provided by @jskillin-idt and makes sure that the outcome of the jandex task is correct (`SUCCESS` or `UP_TO_DATE`) depending if there was a source modification or not.