### PR TITLE
Allow building reproducible Jandex indexes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,11 +93,18 @@ Simply add the desired version (for the maven coordinates `io.smallrye:jandex:<v
 [source,groovy]
 ----
 jandex {
-    version = '3.0.0'
+    version = '3.5.0'
 }
 ----
 
 WARNING: This plugin supports Jandex 3 as a minimum since version `1.0.0`.
+
+=== Reproducible Jandex indexes
+
+To generate reproducible Jandex indexes, serialized index representations are equal across all builds,
+Jandex version 3.5.0 or newer is required.
+
+To enable reproducible jar files in Gradle, visit the `link:https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives[Gradle docs]`.
 
 == Migration
 


### PR DESCRIPTION
Reproducible builds are becoming more and more important to enable the validation of all built artifacts. TL;DR all built artifacts are be 100% equal "byte-by-byte". This also requires that the serialized Jandex indexes to be reproducible.

Since Jandex version 3.5.0, its `IndexWriter` builds reproducible serialized indexes, but only if the `.class` files are indexed (`Indexer.index()`) in a deterministic order.

This change updates the `JandexWorkAction` to first collect all `.class` files to be indexed in a platform agnostic way and then lets Jandex index the `.class` files in a deterministic order. `Path.toURI()` is used as the "sort key", as this representation is file-separator agnostic (`/` vs `\`) and it is (should be?) file-system agnostic.